### PR TITLE
Fix appearance of toolbar

### DIFF
--- a/views/toolbar.css
+++ b/views/toolbar.css
@@ -13,6 +13,8 @@ div#kohana-debug-toolbar table,
 div#kohana-debug-toolbar tr,
 div#kohana-debug-toolbar td,
 div#kohana-debug-toolbar th {
+	width: auto;
+	height: auto;
 	margin: 0;
 	padding: 0;
 	border: 0;


### PR DESCRIPTION
I use styles like:

```
div {
    width: 100%;
    height: 100%;
}
```

in my css-reset. Without this fix toolbar expands to all screen.
