### PR TITLE
Fix for autorender in 3.1

### DIFF
--- a/init.php
+++ b/init.php
@@ -5,4 +5,5 @@ if(Kohana::config('debug_toolbar.firephp_enabled') === TRUE)
 	require_once Kohana::find_file('vendor', 'firephp/packages/core/lib/FirePHPCore/FirePHP.class');
 
 // Render Debug Toolbar on the end of application execution
-register_shutdown_function('debugtoolbar::render');
+if(Kohana::config('debug_toolbar.auto_render') === TRUE)
+	register_shutdown_function('debugtoolbar::render');


### PR DESCRIPTION
The 3.1 branch introduced a regression.
The toolbar is always rendered even if auto_render is disabled.
