### PR TITLE
Fix for auto_render logic issue.

### DIFF
--- a/classes/kohana/debugtoolbar.php
+++ b/classes/kohana/debugtoolbar.php
@@ -409,13 +409,9 @@ abstract class Kohana_DebugToolbar {
 		// Don't auto render toolbar for cli requests
 		if (Kohana::$is_cli)
 			return FALSE;
-		
+
 		// Don't auto render toolbar if $_GET['debug'] = 'false'
 		if (isset($_GET['debug']) and strtolower($_GET['debug']) == 'false')
-			return FALSE;
-
-		// Don't auto render if auto_render config is FALSE
-		if ($config->auto_render !== TRUE)
 			return FALSE;
 
 		return TRUE;

--- a/init.php
+++ b/init.php
@@ -8,4 +8,5 @@ if(Kohana::$config->load('debug_toolbar.firephp_enabled') === TRUE){
 	require_once $firePHP;
 }
 // Render Debug Toolbar on the end of application execution
-register_shutdown_function('debugtoolbar::render');
+if (Kohana::$config->load('debug_toolbar.auto_render') === TRUE)
+    register_shutdown_function('debugtoolbar::render');


### PR DESCRIPTION
Раньше, если auto_render был включен - тулбар добавлялся автоматически (во время отработки shutdown_handler'ов), а если был выключен - необходимо было вручную вызывать метод render();
Сейчас это работает так: если auto_render включен - тулбар как и раньше добавляется автоматически. Если выключен - он не добавляется и его невозможно вставить вручную.

Проблема в том, что если is_enabled() возвращает false - тулбар не рендерится вообще, а должен лишь не рендерится автоматически. На данный момент вызов DebugToolbar::render(true/false) при выключенном auto_render - не работает вообще.

UPD: прошу прощения что на русском, но по-моему для вас это не проблема :)
