### PR TITLE
Added optional parameter for returning toolbar as string.

### DIFF
--- a/classes/kohana/debugtoolbar.php
+++ b/classes/kohana/debugtoolbar.php
@@ -42,9 +42,10 @@ abstract class Kohana_DebugToolbar {
 	 * Renders the Debug Toolbar
 	 *
 	 * @static
+	 * @param bool Will toolbar be printed directly or returned as string [Optional]
 	 * @return bool|string
 	 */
-	public static function render()
+	public static function render($auto_print = TRUE)
 	{
 		if( ! self::is_enabled())
 			return FALSE;
@@ -124,7 +125,10 @@ abstract class Kohana_DebugToolbar {
 
 		$template->set('styles', $styles);
 
-		echo $template->render();
+		if ($auto_print === TRUE)
+		    echo $template->render();
+		else
+		    return $template->render();
 	}
 
 	/**

--- a/init.php
+++ b/init.php
@@ -1,7 +1,7 @@
 <?php defined('SYSPATH') or die('No direct script access.');
 
 // Load FirePHP if it enabled in config
-if(Kohana::$config->load('debug_toolbar.firephp_enabled') === TRUE){
+if(Kohana::$config->load('debug_toolbar.firephp_enabled') && !class_exists('FirePHP')){
 	$file = 'firephp/packages/core/lib/FirePHPCore/FirePHP.class';
 	$firePHP = Kohana::find_file('vendor', $file);
 	if( ! $firePHP) throw new Kohana_Exception('The FirePHP :file could not be found', array(':file'=>$file));


### PR DESCRIPTION
Почему-то возможность вывода тулбара в виде строки где-то потерялась, хотя возвращаемый параметр описан как bool/string. И вызов render() теперь всегда выводит тулбар впереди всего кода, что ломает вёрстку, хидеры и прочее.
Собственно предлагаю вернуть опциональный параметр, как это было раньше и как это описано в Wiki.

Второй коммит - исправление автозагрузки класса FirePHP если он уже был загружен.
