### PR TITLE
Changes for 3.1 branch

### DIFF
--- a/classes/kohana/debugtoolbar.php
+++ b/classes/kohana/debugtoolbar.php
@@ -403,7 +403,7 @@ abstract class Kohana_DebugToolbar {
 			return FALSE;
 
 		// Don't auto render toolbar for ajax requests
-		if (Request::initial()->is_ajax())
+		if (Request::initial() AND Request::initial()->is_ajax())
 			return FALSE;
 
 		// Don't auto render toolbar if $_GET['debug'] = 'false'

--- a/classes/kohana/debugtoolbar.php
+++ b/classes/kohana/debugtoolbar.php
@@ -406,12 +406,12 @@ abstract class Kohana_DebugToolbar {
 		if (Request::initial() AND Request::initial()->is_ajax())
 			return FALSE;
 
-		// Don't auto render toolbar if $_GET['debug'] = 'false'
-		if (isset($_GET['debug']) and strtolower($_GET['debug']) == 'false')
+		// Don't auto render toolbar for cli requests
+		if (Kohana::$is_cli)
 			return FALSE;
 
-		// Don't auto render if auto_render config is FALSE
-		if ($config->auto_render !== TRUE)
+		// Don't auto render toolbar if $_GET['debug'] = 'false'
+		if (isset($_GET['debug']) and strtolower($_GET['debug']) == 'false')
 			return FALSE;
 
 		return TRUE;

--- a/init.php
+++ b/init.php
@@ -1,8 +1,11 @@
 <?php defined('SYSPATH') or die('No direct script access.');
 
+$config = Kohana::config('debug_toolbar');
+
 // Load FirePHP if it enabled in config
-if(Kohana::config('debug_toolbar.firephp_enabled') === TRUE)
+if($config->firephp_enabled === TRUE)
 	require_once Kohana::find_file('vendor', 'firephp/packages/core/lib/FirePHPCore/FirePHP.class');
 
 // Render Debug Toolbar on the end of application execution
-register_shutdown_function('debugtoolbar::render');
+if ($config->auto_render === TRUE)
+	register_shutdown_function('debugtoolbar::render');


### PR DESCRIPTION
It throws an error when it tries to render on empty `Request::$initial`. Added check for `Request::$initial` existance.
And autorender fix (#17) was merged in **3.2** branch, but **3.1** branch was forgotten. It is not fair! :)
## 

_Best regards_,
_Sergei_
