### PR TITLE
Ajax event caching (jQuery v1.8+)

### DIFF
--- a/views/toolbar.js
+++ b/views/toolbar.js
@@ -2,13 +2,13 @@ var debugToolbar = {
 
 	// current toolbar section thats open
 	current: null,
-	
+
 	// current vars and config section open
 	currentvar: null,
-	
+
 	// current config section open
 	currentli: null,
-	
+
 	// toggle a toolbar section
 	show : function(obj) {
 		if (obj == debugToolbar.current) {
@@ -20,7 +20,7 @@ var debugToolbar = {
 			debugToolbar.current = obj;
 		}
 	},
-	
+
 	// toggle a vars and configs section
 	showvar : function(li, obj) {
 		if (obj == debugToolbar.currentvar) {
@@ -38,33 +38,33 @@ var debugToolbar = {
 			debugToolbar.currentli.className = 'active';
 		}
 	},
-	
+
 	// turn an element on
 	on : function(obj) {
 		if (document.getElementById(obj) != null)
 			document.getElementById(obj).style.display = '';
 	},
-	
+
 	// turn an element off
 	off : function(obj) {
 		if (document.getElementById(obj) != null)
 			document.getElementById(obj).style.display = 'none';
 	},
-	
+
 	// toggle an element
 	toggle : function(obj) {
 		if (typeof obj == 'string')
 			obj = document.getElementById(obj);
-			
+
 		if (obj)
 			obj.style.display = obj.style.display == 'none' ? '' : 'none';
 	},
-	
+
 	// close the toolbar
 	close : function() {
 		document.getElementById('kohana-debug-toolbar').style.display = 'none';
 	},
-	
+
 	swap: function() {
 		var toolbar = document.getElementById('debug-toolbar');
 		if (toolbar.className == 'debug-toolbar-align-center') {
@@ -75,7 +75,7 @@ var debugToolbar = {
 			toolbar.className = 'debug-toolbar-align-center';
 		}
 	},
-	
+
 	collapse: function() {
 		debugToolbar.toggle('debug-toolbar-menu');
 	}
@@ -89,34 +89,35 @@ var debugToolbar = {
 if (typeof jQuery != 'undefined') {
 
 	$(document).ready(function(){
-		
+
 		// display ajax button in toolbar
 		$('#toggle-ajax').css({display: 'inline'});
-		
+
+		var debugAjax = $('#debug-ajax');
+
 		// bind ajax event
-		$('#debug-ajax').bind("ajaxComplete", function(event, xmlrequest, ajaxOptions){ 
-			
+		$(document).ajaxComplete(function(event, xmlrequest, ajaxOptions){
+
 			// add a new row to ajax table
-			$('#debug-ajax table').append(
+			debugAjax.find('table').append(
 				'<tr class="even">' +
-					'<td>' + $('#debug-ajax table tr').size() +'<\/td>' + 
-					'<td>jQuery ' + jQuery.fn.jquery + '<\/td>' + 
+					'<td>' + debugAjax.find('table tr').size() +'<\/td>' +
+					'<td>jQuery ' + jQuery.fn.jquery + '<\/td>' +
 					'<td>' + xmlrequest.statusText + ' (' + xmlrequest.status + ')<\/td>' +
 					'<td>' + ajaxOptions.url + '<\/td>' +
 				'<\/tr>'
 			);
-			
+
 			// stripe table
-			$('#debug-ajax table tbody tr:nth-child(even)').attr('class', 'odd');	
-			
+			debugAjax.find('table tbody tr:nth-child(even)').attr('class', 'odd');
+
 			// update count in toolbar
-			$('#toggle-ajax span').text($('#debug-ajax table tr').size()-1);
-			
+			$('#toggle-ajax').find('span').text(debugAjax.find('table tr').size()-1);
+
 		});
 	});
 }
-	
+
 if (typeof Prototype != 'undefined') {
 
 }
-	


### PR DESCRIPTION
Салют.

У jQuery версии 1.8 событие завершения ajax запроса биндится к документу. Из-за того, что бинд до этого делался на таблицу дебаг-тулбара, то в нём не отображалось, что произошёл запрос.
Плюс, небольшой рефакторинг js кода.
