### PR TITLE
Fixed uncaught ErrorException when exception was thrown from initial route

### DIFF
--- a/classes/Kohana/Debugtoolbar.php
+++ b/classes/Kohana/Debugtoolbar.php
@@ -576,9 +576,13 @@ abstract class Kohana_Debugtoolbar {
 			return FALSE;
 		}
 
-		if ( ! empty($config->excluded_routes) && in_array(Route::name(Request::initial()->route()), $config->excluded_routes))
+		if ( ! empty($config->excluded_routes))
 		{
-			return FALSE;
+			$route = Request::initial()->route();
+			if ($route && in_array(Route::name($route), $config->excluded_routes))
+			{
+				return FALSE;
+			}
 		}
 
 		return TRUE;


### PR DESCRIPTION
Patched by simply checking `Request::initial()->route()` result (is `NULL` if shutdown function was called before initial route have passed into `Request`) before trying to obtain its name.
