### PR TITLE
fix eventual bug

### DIFF
--- a/classes/Kohana/Debugtoolbar.php
+++ b/classes/Kohana/Debugtoolbar.php
@@ -496,7 +496,10 @@ abstract class Kohana_Debugtoolbar {
 
 				if ( ! isset($configs[$filename])) {
 					try {
-						$configs[$filename] = Kohana::$config->load($filename)->as_array();
+						$config_file = Kohana::$config->load($filename);
+						if (is_object($config_file)) {
+							$configs[$filename] = $config_file->as_array();
+						}
 					}
 					catch (Exception $e)
 					{


### PR DESCRIPTION
Hello!
I had some strange bug after connecting debug-toolbar:
 Fatal error: Call to a member function as_array() on a non-object in \debug-toolbar\classes\Kohana\Debugtoolbar.php on line 499
I noticed that it happened while trying to call as_array() for my APPATH/config/default.database.php file. It's just a clone of database.php, nothing unusual. So I added a simple check to debug-toolbar and now it works fine!
I think this fix may be helpful.
